### PR TITLE
Handle plain text transcripts in clean/normalize script

### DIFF
--- a/scripts/01_clean_normalize.py
+++ b/scripts/01_clean_normalize.py
@@ -54,6 +54,10 @@ def load_segments(raw_file: Path) -> List[Dict[str, float | str]]:
                 except (TypeError, ValueError):
                     continue
                 segments.append({"start": start, "end": end, "text": row.get("text", "")})
+    elif ext == ".txt":
+        with raw_file.open() as f:
+            for line in f:
+                segments.append({"start": 0.0, "end": 0.0, "text": line.strip()})
     else:
         raise ValueError(f"Unsupported extension: {raw_file}")
     return segments


### PR DESCRIPTION
## Summary
- extend `load_segments` to parse `.txt` transcripts by treating each line as a segment

## Testing
- `pytest`
- `python - <<'PY'
import importlib.util, pathlib, sys
sys.path.append(str(pathlib.Path('scripts').resolve()))
spec = importlib.util.spec_from_file_location('cn', 'scripts/01_clean_normalize.py')
cn = importlib.util.module_from_spec(spec); spec.loader.exec_module(cn)
from pathlib import Path
p = Path('tmp.txt'); p.write_text('hello\nworld\n')
print(cn.load_segments(p))
PY`


------
https://chatgpt.com/codex/tasks/task_b_689a1af89a30832192afe951394c3621