### PR TITLE
fix: use WIKI_PUSH_SECRET for wiki publishing

### DIFF
--- a/.github/workflows/build-wiki.yml
+++ b/.github/workflows/build-wiki.yml
@@ -1,8 +1,9 @@
+---
 name: Build and publish wiki
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
       - 'scripts/**'
       - 'data/**'
@@ -32,12 +33,10 @@ jobs:
       - name: Run pipeline
         run: make all
       - name: Publish to wiki
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git clone https://$GH_TOKEN@github.com/${{ github.repository }}.wiki.git wiki_tmp
+          git clone https://x-access-token:${{ secrets.WIKI_PUSH_SECRET }}@github.com/${{ github.repository }}.wiki.git wiki_tmp
           rsync -a wiki_out/ wiki_tmp/
           cd wiki_tmp
           git add .


### PR DESCRIPTION
## Summary
- use WIKI_PUSH_SECRET secret when cloning/pushing wiki repo
- add YAML document start and cleanup bracket spacing

## Testing
- `yamllint -d '{extends: default, rules: {line-length: {max: 200}, truthy: {check-keys: false}}}' .github/workflows/build-wiki.yml && echo OK`
- `pre-commit run --files .github/workflows/build-wiki.yml` *(fails: InvalidConfigError: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_b_689a28d53a4083218dd574fc46853e66