### PR TITLE
Fix wiki home page filename

### DIFF
--- a/scripts/06_build_wiki.py
+++ b/scripts/06_build_wiki.py
@@ -74,7 +74,7 @@ def build_pages(index: Path, out_dir: Path, only: str | None = None) -> None:
         keywords = ', '.join(r.get('keywords_top', [])[:5])
         years = f"{r.get('earliest','')}–{r.get('latest','')}" if r.get('earliest') else ""
         home_lines.append(f"| [{title}]({filename}) | {duration} | {r.get('words','')} | {r.get('wpm','')} | {r.get('fk_grade','')} | {keywords} | {years} |")
-    (out_dir / "_Home.md").write_text("\n".join(home_lines) + "\n")
+    (out_dir / "Home.md").write_text("\n".join(home_lines) + "\n")
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- Correct wiki generator to write `Home.md` instead of `_Home.md` so GitHub wiki home page displays properly

## Testing
- `python scripts/06_build_wiki.py`
- `ls wiki_out`

------
https://chatgpt.com/codex/tasks/task_b_689a2f08b2fc8321a309cd3fa6873b69