### PR TITLE
Generate sidebar with only video pages

### DIFF
--- a/scripts/06_build_wiki.py
+++ b/scripts/06_build_wiki.py
@@ -208,6 +208,14 @@ def build_pages(index: Path, out_dir: Path, only: str | None = None) -> None:
         )
     (out_dir / "Home.md").write_text("\n".join(home_lines) + "\n")
 
+    sidebar_lines = ["## Videos", "- [Home](Home)", ""]
+    for r in rows:
+        title = r.get("title", r["video_id"])
+        filename = name_map[r["video_id"]]
+        sidebar_lines.append(f"- [{title}]({filename})")
+    sidebar_lines.append("")
+    (out_dir / "_Sidebar.md").write_text("\n".join(sidebar_lines))
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)


### PR DESCRIPTION
## Summary
- Generate a `_Sidebar.md` during wiki build to list only video pages and the home link.

## Testing
- `python scripts/06_build_wiki.py`


------
https://chatgpt.com/codex/tasks/task_b_689a4a135d5883218214a36e265a1364