### PR TITLE
Fix topic links for GitHub wiki

### DIFF
--- a/scripts/06_build_wiki.py
+++ b/scripts/06_build_wiki.py
@@ -22,7 +22,7 @@ def link_entity(name: str, kind: str) -> str:
 
 
 def link_topic(keyword: str) -> str:
-    return f"[{keyword}](topics/{safe_name(keyword)})"
+    return f"[{keyword}]({safe_name(keyword)})"
 
 
 def info_box(entry: Dict, url: str) -> List[str]:
@@ -148,22 +148,19 @@ def build_entity_pages(entity_map: Dict[str, Dict[str, List[Dict]]], topic_map: 
                 lines.append(f"- [{title_map.get(vid, vid)}]({name_map[vid]})")
             (kind_dir / f"{safe_name(name)}.md").write_text("\n".join(lines) + "\n")
 
-    topics_dir = out_dir / "topics"
     topic_names: List[str] = []
-    if topic_map:
-        topics_dir.mkdir(parents=True, exist_ok=True)
     for kw, entries in sorted(topic_map.items()):
         topic_names.append(kw)
         lines = [f"# {kw}", "", "Referenced in:", ""]
         for e in sorted(entries, key=lambda x: x.get("title", x["video_id"])):
             vid = e["video_id"]
             lines.append(f"- [{title_map.get(vid, vid)}]({name_map[vid]})")
-        (topics_dir / f"{safe_name(kw)}.md").write_text("\n".join(lines) + "\n")
+        (out_dir / f"{safe_name(kw)}.md").write_text("\n".join(lines) + "\n")
 
     if topic_names:
         index_lines = ["# Topics", "", "List of keywords:", ""]
         for kw in sorted(topic_names):
-            index_lines.append(f"- [{kw}](topics/{safe_name(kw)})")
+            index_lines.append(f"- [{kw}]({safe_name(kw)})")
         (out_dir / "Topics.md").write_text("\n".join(index_lines) + "\n")
 
     return topic_names
@@ -226,7 +223,7 @@ def build_pages(index: Path, out_dir: Path, only: str | None = None) -> None:
     if topic_names:
         sidebar_lines.extend(["", "## Topics", ""])
         for kw in sorted(topic_names):
-            sidebar_lines.append(f"- [{kw}](topics/{safe_name(kw)})")
+            sidebar_lines.append(f"- [{kw}]({safe_name(kw)})")
     sidebar_lines.append("")
     (out_dir / "_Sidebar.md").write_text("\n".join(sidebar_lines))
 


### PR DESCRIPTION
## Summary
- build topic pages at the wiki root so keyword links resolve correctly

## Testing
- `python scripts/06_build_wiki.py --help`
- `python -m py_compile scripts/06_build_wiki.py`


------
https://chatgpt.com/codex/tasks/task_b_689a9217a85483218ebbf4385d3b964f