### PR TITLE
Integrate enhanced index into wiki build

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,4 +265,4 @@ Get-ChildItem audio\*.m4a | ForEach-Object {
 
 ## Enhanced index page
 
-Run `python scripts/07_build_index_enhanced.py` after generating wiki pages to overwrite `wiki_out/Home.md` with a searchable, sortable table that highlights new uploads and missing data.
+Running `python scripts/06_build_wiki.py` (or `make wiki`) now writes `wiki_out/Home.md` with a searchable, sortable table that highlights new uploads and missing data.


### PR DESCRIPTION
## Summary
- ensure `make wiki` produces a Home.md with search/filtering by invoking the enhanced index builder after all pages are generated
- document that the wiki build now automatically writes a searchable `Home.md`

## Testing
- `python -m py_compile scripts/06_build_wiki.py scripts/07_build_index_enhanced.py`
- `python scripts/06_build_wiki.py --only QJxbyu-9Tj0`


------
https://chatgpt.com/codex/tasks/task_b_689b4f8f5430832180e4741f3b589a01