### PR TITLE
Fix broken transcript links in video page

### DIFF
--- a/docs/videos/us-special-forces-confession.mdx
+++ b/docs/videos/us-special-forces-confession.mdx
@@ -8,16 +8,14 @@ tags:
   - topic:untagged
 ---
 
-import Link from '@docusaurus/Link';
-
 # US Special Forces Confession - I Recovered Crashed UFOs: Fact or Fiction?
 
 **Published:** unknown · **Duration:** unknown
 
 ## Files & Links
-- Link: <Link to="https://www.youtube.com/watch?v=DcvuglS7ps4">YouTube</Link>
-- Transcript: <Link to="/transcripts/yt-DcvuglS7ps4/clean.txt">download .txt</Link>
-- Captions: <Link to="/transcripts/yt-DcvuglS7ps4/original.vtt">.vtt</Link>
+- [YouTube](https://www.youtube.com/watch?v=DcvuglS7ps4)
+- Transcript: [download .txt](/transcripts/yt-DcvuglS7ps4/clean.txt)
+- Captions: [.vtt](/transcripts/yt-DcvuglS7ps4/original.vtt)
 
 ## Entities
 _No entities tagged yet_

--- a/scripts/06_build_pages.py
+++ b/scripts/06_build_pages.py
@@ -196,7 +196,7 @@ def build_video_pages(videos: List[Video]) -> Dict[str, List[Tuple[str, str]]]:
         fm = [
             "---",
             f"id: {v.id}",
-            f'title: "{v.title.replace('"', '\"')}",'
+            f'title: "{v.title.replace("\"", "\\\"")}",'
             f"published_at: {v.published_at or ''}",
             f"duration: {v.duration or ''}",
             f"tags: {v.tags!r}",

--- a/scripts/06_build_pages.py
+++ b/scripts/06_build_pages.py
@@ -196,7 +196,7 @@ def build_video_pages(videos: List[Video]) -> Dict[str, List[Tuple[str, str]]]:
         fm = [
             "---",
             f"id: {v.id}",
-            f"title: \"{v.title.replace('"','\\"')}\"",
+            f'title: "{v.title.replace('"', '\"')}",'
             f"published_at: {v.published_at or ''}",
             f"duration: {v.duration or ''}",
             f"tags: {v.tags!r}",

--- a/scripts/generate_video_pages.py
+++ b/scripts/generate_video_pages.py
@@ -31,8 +31,6 @@ duration: {duration}
 tags:
 {tags_yaml}---
 
-import Link from '@docusaurus/Link';
-
 # {title_heading}
 
 **Published:** {published_at} · **Duration:** {duration}
@@ -62,12 +60,12 @@ def build_video_page(item: dict, transcript_text: str) -> str:
     links = []
     yt = item.get("sources", {}).get("youtube")
     if yt:
-        links.append(f"- Link: <Link to=\"{yt}\">YouTube</Link>")
+        links.append(f"- [YouTube]({yt})")
     served_txt = item.get("sources", {}).get("transcript_txt_served", item["sources"]["transcript_txt"])
-    links.append(f"- Transcript: <Link to=\"/{served_txt}\">download .txt</Link>")
+    links.append(f"- Transcript: [download .txt](/{served_txt})")
     vtt = item.get("sources", {}).get("transcript_vtt_served") or item.get("sources", {}).get("transcript_vtt")
     if vtt:
-        links.append(f"- Captions: <Link to=\"/{vtt}\">.vtt</Link>")
+        links.append(f"- Captions: [.vtt](/{vtt})")
     links_block = "\n".join(links) if links else "- (no external links)"
 
     ent = ent_links(item.get("entities", {}))


### PR DESCRIPTION
## Summary
- fix broken link detection in `us-special-forces-confession` page by using markdown links to transcripts

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689cab21cc78832186816342b5b02ff5