### PR TITLE
Fix f-string escaping in page builder

### DIFF
--- a/scripts/06_build_pages.py
+++ b/scripts/06_build_pages.py
@@ -193,10 +193,11 @@ def build_video_pages(videos: List[Video]) -> Dict[str, List[Tuple[str, str]]]:
             index_for_entities[key].append((pf, v.title))
 
         # Front matter and body
+        escaped_title = v.title.replace('"', '\\"')
         fm = [
             "---",
             f"id: {v.id}",
-            f'title: "{v.title.replace("\"", "\\\"")}",'
+            f'title: "{escaped_title}",'
             f"published_at: {v.published_at or ''}",
             f"duration: {v.duration or ''}",
             f"tags: {v.tags!r}",


### PR DESCRIPTION
## Summary
- pre-escape video titles before inserting into front matter to avoid backslash in f-string expressions

## Testing
- `python -m py_compile scripts/06_build_pages.py`


------
https://chatgpt.com/codex/tasks/task_b_689cb61e9f4883219e5c53a4e0303217